### PR TITLE
Fix InsightObjectAttributes valueError for dates

### DIFF
--- a/jira_insight/insight.py
+++ b/jira_insight/insight.py
@@ -189,6 +189,8 @@ class InsightObjectAttribute:
                 "URL",
                 "Email",
                 "Textarea",
+                "Date",
+                "DateTime",
             ]:
                 return value_json.get("value", None)
             if self.object_type_attribute.attribute_type == "Status":
@@ -199,10 +201,6 @@ class InsightObjectAttribute:
                 return float(value_json.get("value", None))
             if self.object_type_attribute.attribute_type == "Boolean":
                 return value_json.get("value", "false") == "true"
-            if self.object_type_attribute.attribute_type == "Date":
-                return value_json.get("value", None)
-            if self.object_type_attribute.attribute_type == "Date Time":
-                return value_json.get("value", None)
 
     def __str__(self):
         return f"InsightObjectAttribute: {self.name}, Value: {self.value}"

--- a/jira_insight/insight.py
+++ b/jira_insight/insight.py
@@ -190,7 +190,7 @@ class InsightObjectAttribute:
                 "Email",
                 "Textarea",
                 "Date",
-                "DateTime",
+                "Date Time",
             ]:
                 return value_json.get("value", None)
             if self.object_type_attribute.attribute_type == "Status":

--- a/jira_insight/insight.py
+++ b/jira_insight/insight.py
@@ -200,13 +200,9 @@ class InsightObjectAttribute:
             if self.object_type_attribute.attribute_type == "Boolean":
                 return value_json.get("value", "false") == "true"
             if self.object_type_attribute.attribute_type == "Date":
-                return datetime.datetime.strptime(
-                    value_json.get("value", None), "%d.%m.%Y"
-                ).date()
+                return value_json.get("value", None)
             if self.object_type_attribute.attribute_type == "Date Time":
-                return datetime.datetime.strptime(
-                    value_json.get("value", None), "%d.%m.%Y %H:%M"
-                )
+                return value_json.get("value", None)
 
     def __str__(self):
         return f"InsightObjectAttribute: {self.name}, Value: {self.value}"


### PR DESCRIPTION
When reading InsightObjectAttributes values that are of type Date or
DateTime with the wrong format _strptime_datetime will raise ValueError.

This commit removes the date/datetime parsing from insight.py and lets
the user do the conversion to datetime objects.

See issue #6